### PR TITLE
Fix "double Remove-ContainerNetwork" workaround

### DIFF
--- a/CIScripts/Test/GetTestConfigurationJuni.ps1
+++ b/CIScripts/Test/GetTestConfigurationJuni.ps1
@@ -5,7 +5,11 @@ function Get-TestConfiguration {
         ControllerHostUsername = "ubuntu";
         ControllerHostPassword = "ubuntu";
         AdapterName = "Ethernet1";
-        VMSwitchName = "Layered Ethernet1";
+
+        # When creating network using `docker network create`
+        # the switch gets a `Layered_<Adapter>` name, but docker driver
+        # uses space instead of `_`. We support both names here.
+        VMSwitchName = "Layered?Ethernet1";
         VHostName = "vEthernet (HNSTransparent)"
         ForwardingExtensionName = "vRouter forwarding extension";
         AgentConfigFilePath = "C:\ProgramData\Contrail\etc\contrail\contrail-vrouter-agent.conf";

--- a/CIScripts/Test/TestConfigurationUtils.ps1
+++ b/CIScripts/Test/TestConfigurationUtils.ps1
@@ -71,7 +71,9 @@ function Enable-VRouterExtension {
     Write-Host "Enabling Extension"
 
     Invoke-Command -Session $Session -ScriptBlock {
-        New-ContainerNetwork -Mode Transparent -NetworkAdapterName $Using:AdapterName -Name $Using:ContainerNetworkName | Out-Null
+        docker network create -d transparent --ipam-driver windows `
+            -o com.docker.network.windowsshim.interface=$Using:AdapterName $Using:ContainerNetworkName
+
         $Extension = Get-VMSwitch | Get-VMSwitchExtension -Name $Using:ForwardingExtensionName | Where-Object Enabled
         if ($Extension) {
             Write-Warning "Extension already enabled on: $($Extension.SwitchName)"
@@ -165,7 +167,6 @@ function Disable-DockerDriver {
     Invoke-Command -Session $Session -ScriptBlock {
         Stop-Service docker | Out-Null
         Get-NetNat | Remove-NetNat -Confirm:$false
-        Get-ContainerNetwork | Remove-ContainerNetwork -ErrorAction SilentlyContinue -Force
         Get-ContainerNetwork | Remove-ContainerNetwork -Force
         Start-Service docker | Out-Null
     }


### PR DESCRIPTION
Tries to fix workaround introduced in https://github.com/codilime/contrail-windows-ci/pull/82

When using:
* `New-ContainerNetwork`
* `Remove-ContainerNetwork`

the latter fails with "Incorrect parameter"
and `Remove-ConatinerNetwork` has to be redone.
This is how `Enable-VRouterExtension` works currently.

Similar mode of failure occurs with:
* `docker network create`
* `docker network rm`

Somehow, the clean path is:
* `docker network create`
* `docker network prune` – this actually causes the same HNS error as `rm` (*The parameter is incorrect*), but `prune` exits cleanly regardless.
* `Remove-ContainerNetwork`

Which is what this commit uses

---

See https://github.com/docker/for-win/issues/1239