### PR TITLE
ansible: bump to 2.4.2.0 in requirements.txt

### DIFF
--- a/ansible/python-requirements.txt
+++ b/ansible/python-requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.4.0.0
+ansible==2.4.2.0
 
 # For management of windows nodes
 pywinrm>=0.2.2


### PR DESCRIPTION
2.4.2.0 version includes necessary fixes for problems with TLSv1 (https://github.com/ansible/ansible/pull/32053)